### PR TITLE
Fix: ZERO_SERVER environment variable

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,7 @@ console.log(import.meta.env);
 const z = new Zero({
   userID,
   auth: () => encodedJWT,
-  server: import.meta.env.ZERO_SERVER,
+  server: import.meta.env.VITE_ZERO_SERVER,
   schema,
   // This is often easier to develop with if you're frequently changing
   // the schema. Switch to 'idb' for local-persistence.

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -104,7 +104,7 @@ export default $config({
       path: './',
       environment: {
         HONO_SERVER: honoFunction.url,
-        ZERO_SERVER: service.url,
+        VITE_ZERO_SERVER: service.url,
       },
       build: {
         command: "npm run build",


### PR DESCRIPTION
In development, my ZERO_SERVER does not get passed without the VITE_ prefix [link](https://sst.dev/docs/component/aws/static-site#set-environment-variables) 

Also, even when I pass the server url, my websockets are not working. Were you able to get this working in dev/prod?

